### PR TITLE
Condition set for adding TLS12 will always be true

### DIFF
--- a/snippets/powershell/Get-NB-Alerts.ps1
+++ b/snippets/powershell/Get-NB-Alerts.ps1
@@ -43,7 +43,7 @@ function InitialSetup()
 
     # Force TLS v1.2
     try {
-        if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
+        if ([Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
             [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
         }
     }

--- a/snippets/powershell/Get-NB-Images.ps1
+++ b/snippets/powershell/Get-NB-Images.ps1
@@ -43,7 +43,7 @@ function InitialSetup()
 
     # Force TLS v1.2
     try {
-        if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
+        if ([Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
             [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
         }
     }

--- a/snippets/powershell/Get-NB-Jobs.ps1
+++ b/snippets/powershell/Get-NB-Jobs.ps1
@@ -43,7 +43,7 @@ function InitialSetup()
 
     # Force TLS v1.2
     try {
-        if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
+        if ([Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
             [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
         }
     }

--- a/snippets/powershell/Post-NB-Cleanup-Assets.ps1
+++ b/snippets/powershell/Post-NB-Cleanup-Assets.ps1
@@ -52,7 +52,7 @@ function InitialSetup()
 	
     # Force TLS v1.2
     try {
-        if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
+        if ([Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
            [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
         }
     }


### PR DESCRIPTION
-notcontains was wrongly used here. Changed -notcontains to -notmatch and this has fixed the issue. Please review it and let me know if any changes needed