### PR TITLE
Sample Perl scripts for converting rbac principals behind registered API Keys

### DIFF
--- a/recipes/perl/access-control/README.md
+++ b/recipes/perl/access-control/README.md
@@ -1,0 +1,22 @@
+# NetBackup API Code Examples for Perl
+
+This directory contains code samples for converting RBAC principals behind registered API keys.
+
+## Disclaimer
+
+These scripts are only meant to be used as reference. They are not intended to be used in production environment.
+
+## Prerequisites
+
+- NetBackup 8.3 or higher
+- Perl 5.20.2 or higher
+
+## Executing the recipes in Perl
+
+Use the following command to get RBAC principals behind registered API keys, get existing roles for RBAC gen1 roles, and create new access control roles accordingly.
+
+- `perl list_api_keys.pl -hostname <hostname> -username <username> -password <password> [-domain_name <domain_name>] [-domain_type <domain_type>]` 
+
+- `perl list_gen1_roles.pl -hostname <hostname> -username <username> -password <password> [-domain_name <domain_name>] [-domain_type <domain_type>]` 
+
+- `perl create_access_control_role.pl -hostname <hostname> -username <username> -password <password> -role_name <role_name> [-role_description <role_description>] [-domain_name <domain_name>] [-domain_type <domain_type>]` 

--- a/recipes/perl/access-control/access_control_api_requests.pl
+++ b/recipes/perl/access-control/access_control_api_requests.pl
@@ -1,0 +1,97 @@
+#!/usr/bin/env perl
+
+use LWP::UserAgent;
+use JSON;
+
+my $content_type = "application/vnd.netbackup+json; version=4.0";
+
+# Initialize HTTP client
+my $http = LWP::UserAgent->new(
+        ssl_opts => { verify_hostname => 0, verify_peer => 0 },
+        protocols_allowed => ['https']
+);
+
+# List api keys
+sub list_api_keys {
+    my ($base_url, $token) = @_;
+
+    my $media_type = "application/vnd.netbackup+json;version=4";
+    my $api_keys_url = "$base_url/security/api-keys";
+
+    # Update http client with default header
+    $http->default_header('Accept' => $media_type);
+    $http->default_header('Authorization' => $token);
+
+    my $response = $http->get($api_keys_url);
+
+    unless ($response->is_success) {
+        print "HTTP GET error code: ", $response->code, "\n";
+        print "HTTP GET error message: ", $response->message, "\n";
+
+        die "Failed to get api keys.\n";
+    }
+
+    my $response_content = decode_json($response->content);
+    print "API Keys: ", $response_content, "\n";
+}
+
+# List rbac roles
+sub list_gen1_roles {
+    my ($base_url, $token) = @_;
+
+    my $media_type = "application/vnd.netbackup+json;version=1";
+    my $gen1_roles_url = "$base_url/rbac/roles";
+
+    $http->default_header('Accept' => $media_type);
+    $http->default_header('Authorization' => $token);
+
+    my $response = $http->get($gen1_roles_url);
+
+    unless ($response->is_success) {
+        print "HTTP GET error code: ", $response->code, "\n";
+        print "HTTP GET error message: ", $response->message, "\n";
+
+        die "Failed to get Gen-1 roles.\n";
+    }
+
+    my $response_content = decode_json($response->content);
+    print "Gen-1 roles: ", $response_content, "\n";
+}
+
+# Create access control role
+sub create_access_control_role {
+    my ($base_url, $token, $name, $desc) = @_;
+
+    my $media_type = "application/vnd.netbackup+json;version=4";
+    my $access_control_roles_url = "$base_url/access-control/roles";
+
+    $http->default_header('Accept' => $media_type);
+    $http->default_header('Authorization' => $token);
+
+    my %role = (
+        'data' => {
+            'type' => 'accessControlRole',
+            'attribute' => {
+                'name' => $name,
+                'description' => $desc
+	    }
+	}
+    );
+    
+    my $role_body = encode_json(\%role);
+
+    my $response = $http->post($access_control_role_url, 'Content-Type' => $media_type, Content => $role_body);
+
+    unless ($response->is_success) {
+        print "HTTP POST error code: ", $response->code, "\n";
+        print "HTTP POST error message: ", $response->message, "\n";
+
+        die "Failed to create $name role.\n";
+    }
+
+    my $response_content = decode_json($response->content);
+    my $new_role_id = $response_content->{data}{id};
+    print "$name role created with ID $new_role_id\n";
+}
+
+1;

--- a/recipes/perl/access-control/create_access_control_role.pl
+++ b/recipes/perl/access-control/create_access_control_role.pl
@@ -1,0 +1,47 @@
+#!/usr/bin/env perl
+
+use Getopt::Long;
+
+require 'api_requests.pl';
+require 'access_control_api_requests.pl';
+
+my $hostname;
+my $username;
+my $password;
+my $domain_name;
+my $domain_type;
+my $role_name;
+my $role_description;
+
+my $base_url;
+my $token;
+
+GetOptions(
+    'hostname=s' => \$hostname,
+    'username=s' => \$username,
+    'password=s' => \$password,
+    'domain_name=s' => \$domain_name,
+    'domain_type=s' => \$domain_type,
+    'role_name=s' => \$role_name,
+    'role_description=s' => \$role_description
+) or pod2usage(2);
+
+$hostname ne "" or die "Please provide a value for '--hostname'\n";
+
+$username ne "" or die "Please provide a value for '--username'\n";
+
+$password ne "" or die "Please provide a value for '--password'\n";
+
+$role_name ne "" or die "Please provide a value for '--role_name'\n";
+
+$base_url = "https://$hostname/netbackup";
+$token = perform_login($base_url, $username, $password, $domain_name, $domain_type);
+
+create_access_control_role($base_url, $token, $role_name, $role_description);
+
+
+sub print_usage {
+    say "Usage:";
+    say "perl create_access_control_role.pl -hostname <master_server> -username <username> -password <password> -role_name <role_name> [-role_description <role_description>] [-domain_name <domain_name>] [-domain_type <domain_type>]";
+}
+

--- a/recipes/perl/access-control/list_api_keys.pl
+++ b/recipes/perl/access-control/list_api_keys.pl
@@ -1,0 +1,41 @@
+#!/usr/bin/env perl
+
+use Getopt::Long;
+
+require 'api_requests.pl';
+require 'access_control_api_requests.pl';
+
+my $hostname;
+my $username;
+my $password;
+my $domain_name;
+my $domain_type;
+
+my $base_url;
+my $token;
+
+GetOptions(
+    'hostname=s' => \$hostname,
+    'username=s' => \$username,
+    'password=s' => \$password,
+    'domain_name=s' => \$domain_name,
+    'domain_type=s' => \$domain_type
+) or pod2usage(2);
+
+$hostname ne "" or die "Please provide a value for '--hostname'\n";
+
+$username ne "" or die "Please provide a value for '--username'\n";
+
+$password ne "" or die "Please provide a value for '--password'\n";
+
+$base_url = "https://$hostname/netbackup";
+$token = perform_login($base_url, $username, $password, $domain_name, $domain_type);
+
+list_api_keys($base_url, $token);
+
+
+sub print_usage {
+    say "Usage:";
+    say "perl list_api_keys.pl -hostname <master_server> -username <username> -password <password> [-domain_name <domain_name>] [-domain_type <domain_type>]";
+}
+

--- a/recipes/perl/access-control/list_gen1_roles.pl
+++ b/recipes/perl/access-control/list_gen1_roles.pl
@@ -1,0 +1,41 @@
+#!/usr/bin/env perl
+
+use Getopt::Long;
+
+require 'api_requests.pl';
+require 'access_control_api_requests.pl';
+
+my $hostname;
+my $username;
+my $password;
+my $domain_name;
+my $domain_type;
+
+my $base_url;
+my $token;
+
+GetOptions(
+    'hostname=s' => \$hostname,
+    'username=s' => \$username,
+    'password=s' => \$password,
+    'domain_name=s' => \$domain_name,
+    'domain_type=s' => \$domain_type
+) or pod2usage(2);
+
+$hostname ne "" or die "Please provide a value for '--hostname'\n";
+
+$username ne "" or die "Please provide a value for '--username'\n";
+
+$password ne "" or die "Please provide a value for '--password'\n";
+
+$base_url = "https://$hostname/netbackup";
+$token = perform_login($base_url, $username, $password, $domain_name, $domain_type);
+
+list_gen1_roles($base_url, $token);
+
+
+sub print_usage {
+    say "Usage:";
+    say "perl list_gen1_roles.pl -hostname <master_server> -username <username> -password <password> [-domain_name <domain_name>] [-domain_type <domain_type>]";
+}
+


### PR DESCRIPTION
When a customer has api keys configured, the principals for those api keys will need to be re-configured with RBAC gen2. These example scripts will help a customer to find out configured principals behind those api keys and to create roles for those principals for RBAC gen2.