### PR TITLE
Changed SecurityProtocol assignment from "+=" to Bitwise OR

### DIFF
--- a/snippets/powershell/Get-NB-Images.ps1
+++ b/snippets/powershell/Get-NB-Images.ps1
@@ -44,7 +44,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
-            [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+            [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {


### PR DESCRIPTION
The append / addition operator is not working in PS 4.0. The bitwise OR assignment method should be compatible with more PS versions.