### PR TITLE
Issue/append vs bitwise or

### DIFF
--- a/snippets/powershell/Get-NB-Alerts.ps1
+++ b/snippets/powershell/Get-NB-Alerts.ps1
@@ -44,7 +44,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
-            [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+            [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/Get-NB-Images.ps1
+++ b/snippets/powershell/Get-NB-Images.ps1
@@ -44,7 +44,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
-            [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+            [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/Get-NB-Jobs.ps1
+++ b/snippets/powershell/Get-NB-Jobs.ps1
@@ -44,7 +44,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
-            [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+            [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/Post-NB-Cleanup-Assets.ps1
+++ b/snippets/powershell/Post-NB-Cleanup-Assets.ps1
@@ -53,7 +53,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Delete-NB-delete-disk-pool.ps1
+++ b/snippets/powershell/storage/Delete-NB-delete-disk-pool.ps1
@@ -47,7 +47,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Delete-NB-delete-storage-server.ps1
+++ b/snippets/powershell/storage/Delete-NB-delete-storage-server.ps1
@@ -47,7 +47,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Delete-NB-delete-storage-unit.ps1
+++ b/snippets/powershell/storage/Delete-NB-delete-storage-unit.ps1
@@ -47,7 +47,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Get-NB-get-disk-pool-by-id.ps1
+++ b/snippets/powershell/storage/Get-NB-get-disk-pool-by-id.ps1
@@ -47,7 +47,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Get-NB-get-disk-pool.ps1
+++ b/snippets/powershell/storage/Get-NB-get-disk-pool.ps1
@@ -46,7 +46,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Get-NB-get-storage-server-by-id.ps1
+++ b/snippets/powershell/storage/Get-NB-get-storage-server-by-id.ps1
@@ -47,7 +47,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Get-NB-get-storage-server.ps1
+++ b/snippets/powershell/storage/Get-NB-get-storage-server.ps1
@@ -46,7 +46,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Get-NB-get-storage-unit-by-id.ps1
+++ b/snippets/powershell/storage/Get-NB-get-storage-unit-by-id.ps1
@@ -47,7 +47,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Get-NB-get-storage-unit.ps1
+++ b/snippets/powershell/storage/Get-NB-get-storage-unit.ps1
@@ -46,7 +46,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Patch-NB-update-ad-storage-server.ps1
+++ b/snippets/powershell/storage/Patch-NB-update-ad-storage-server.ps1
@@ -48,7 +48,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Patch-NB-update-cloud-storage-server.ps1
+++ b/snippets/powershell/storage/Patch-NB-update-cloud-storage-server.ps1
@@ -48,7 +48,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Patch-NB-update-disk-pool.ps1
+++ b/snippets/powershell/storage/Patch-NB-update-disk-pool.ps1
@@ -48,7 +48,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Patch-NB-update-msdp-storage-server.ps1
+++ b/snippets/powershell/storage/Patch-NB-update-msdp-storage-server.ps1
@@ -47,7 +47,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Patch-NB-update-storage-unit.ps1
+++ b/snippets/powershell/storage/Patch-NB-update-storage-unit.ps1
@@ -48,7 +48,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Post-NB-create-ad-disk-pool.ps1
+++ b/snippets/powershell/storage/Post-NB-create-ad-disk-pool.ps1
@@ -46,7 +46,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Post-NB-create-ad-storage-server.ps1
+++ b/snippets/powershell/storage/Post-NB-create-ad-storage-server.ps1
@@ -46,7 +46,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Post-NB-create-ad-storage-unit.ps1
+++ b/snippets/powershell/storage/Post-NB-create-ad-storage-unit.ps1
@@ -46,7 +46,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Post-NB-create-cloud-disk-pool.ps1
+++ b/snippets/powershell/storage/Post-NB-create-cloud-disk-pool.ps1
@@ -46,7 +46,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Post-NB-create-cloud-storage-server.ps1
+++ b/snippets/powershell/storage/Post-NB-create-cloud-storage-server.ps1
@@ -46,7 +46,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Post-NB-create-cloud-storage-unit.ps1
+++ b/snippets/powershell/storage/Post-NB-create-cloud-storage-unit.ps1
@@ -46,7 +46,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Post-NB-create-cloud-storage-unit.ps1
+++ b/snippets/powershell/storage/Post-NB-create-cloud-storage-unit.ps1
@@ -46,7 +46,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
+           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
         }
     }
     catch {

--- a/snippets/powershell/storage/Post-NB-create-msdp-disk-pool.ps1
+++ b/snippets/powershell/storage/Post-NB-create-msdp-disk-pool.ps1
@@ -46,7 +46,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Post-NB-create-msdp-storage-server.ps1
+++ b/snippets/powershell/storage/Post-NB-create-msdp-storage-server.ps1
@@ -46,7 +46,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {

--- a/snippets/powershell/storage/Post-NB-create-msdp-storage-unit.ps1
+++ b/snippets/powershell/storage/Post-NB-create-msdp-storage-unit.ps1
@@ -46,7 +46,7 @@ function InitialSetup()
     # Force TLS v1.2
     try {
         if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
-           [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+           [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
         }
     }
     catch {


### PR DESCRIPTION
PowerShell Append for SecurityProtocol Not working in PS 4.0

Needed to change SecurityProtocol assignment from "+=" to Bitwise OR

The append / addition operator is not working in PS 4.0. The bitwise OR assignment method should be compatible with more PS versions.