### PR TITLE
Adding RBAC design change information warning users that some scripts…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,25 @@ Pre-requisites:
 ##### Tools
 The `tools` folder contains utilities that have proven useful in the development of projects using NetBackup APIs, but do not provide any API usage examples.  Again, these tools are not for production use, but they may be of some use in your work.
 
+#### NetBackup 8.3 RBAC Design Shift
+NetBackup 8.3 introduced a major change in its RBAC configuration and enforcement design.  
+
+RBAC was introduced to NetBackup in the 8.1.2 release, offering access control for a limited number of security settings and workloads.  That access control configuration was based on a dynamic object-level enforcement model using “Access Rules”.
+
+With the NetBackup 8.3 release, RBAC has moved away from the dynamic access rule design.  
+The new RBAC allows more granular permissions, improved flexibility and greater control. The RBAC design is now based on Access Control Lists (ACLs) and closely follows the ANSI INCITS 359-2004.  While the earlier design of RBAC enforcement was dynamic in nature, the new RBAC is static in its configuration.
+
+The system-defined roles shipped with NetBackup also changed from 8.1.2 to the 8.3 release.  In 8.1.2, there were three system-defined roles available for RBAC configuration.  In the 8.3 release, this was simplified to offer a single “Administrator” role which has all privileges for RBAC.
+
+Due to the significant design shift, automatic upgrade conversion of 8.1.2 RBAC roles to the new 8.3 roles is not feasible.  However, tools are available to migrate the Backup administrator role and create a new Security administrator role for the users that had the old RBAC Security administrator role. Other roles must be reconfigured manually. 
+There is also a script in this repository available to generate templated NetBackup roles.
+See **/recipes/perl/rbac-roles/rbac_role_templates.pl**
+
+
+Any API keys in use prior to upgrade will still be valid, however, the underlying access granted those API keys must
+ be reconfigured using the new RBAC configuration, after which any active user sessions must be removed.
+A utility script exists in this repository to help convert active API keys after upgrade to NetBackup 8.3.  
+See **/recipes/perl/access-control/access_control_api_requests.pl**
+
+Most of the API examples in this repository assume a valid JWT (Json Web Token) or API Key issued by NetBackup and do not incorporate role configuration as part of the script. 
+However, there may be some examples which do configure RBAC as part of the script and have not yet been updated to use the RBAC design.

--- a/recipes/perl/policies/README.md
+++ b/recipes/perl/policies/README.md
@@ -9,6 +9,12 @@ These scripts are only meant to be used as a reference. If you intend to use the
 #### Pre-requisites:
 
 - NetBackup 8.1.2 or higher
+
+    - **NOTE:**  The following scripts configure access control using the old RBAC design and will only work on NetBackup
+ release 8.1.2 or 8.2.
+        - recipes/perl/policies/api_requests_rbac_policy.pl
+        - recipes/perl/policies/rbac_filtering_in_policy.pl
+
 - Perl 5.20.2 or higher
 
 #### Executing the recipes in perl

--- a/recipes/powershell/policies/README.md
+++ b/recipes/powershell/policies/README.md
@@ -10,6 +10,11 @@ These scripts are only meant to be used as a reference. If you intend to use the
 
 Pre-requisites:
 - NetBackup 8.1.2 or higher
+
+    - **NOTE:**  The following scripts configure access control using the old RBAC design and will only work on NetBackup
+ release 8.1.2 or 8.2.
+        - recipes/perl/policies/rbac_filtering_in_policy.ps1
+        
 - PowerShell 4.0 or higher
 
 Use the following commands to run the PowerShell samples.

--- a/recipes/python/policies/README.md
+++ b/recipes/python/policies/README.md
@@ -10,6 +10,12 @@ These samples are provided only as reference and not meant for production use.
 
 Pre-requisites:
 - NetBackup 8.1.2 or higher
+
+    - **NOTE:**  The following scripts configure access control using the old RBAC design and will only work on NetBackup
+ release 8.1.2 or 8.2.
+        - recipes/perl/policies/api_requests_rbac_policy.py
+        - recipes/perl/policies/rbac_filtering_in_policy.py
+        
 - Python 3.5 or higher
 - Python modules: `requests`
 


### PR DESCRIPTION
Adding RBAC design change information warning users that some scripts which incorporate RBAC configuration as part of the script may not yet have been updated to use the new RBAC design.
Adding content to the top-level README.md as well as to the README.md file of the individual folders that have scripts using the old RBAC.

